### PR TITLE
Added feature to recover missed alerts through heartbeat messages

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -681,16 +681,16 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "3.2.2",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "831a1eb7d260925528cdbb49cc1866c0357cf147"
+                "reference": "69958152e661aa9c14e80d1ee4962863485aa60b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/831a1eb7d260925528cdbb49cc1866c0357cf147",
-                "reference": "831a1eb7d260925528cdbb49cc1866c0357cf147",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/69958152e661aa9c14e80d1ee4962863485aa60b",
+                "reference": "69958152e661aa9c14e80d1ee4962863485aa60b",
                 "shasum": ""
             },
             "require": {
@@ -712,7 +712,10 @@
             "require-dev": {
                 "doctrine/coding-standard": "^12.0",
                 "phpbench/phpbench": "^1.0",
-                "phpstan/phpstan": "1.11.1",
+                "phpdocumentor/guides-cli": "^1.4",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "1.12.6",
+                "phpstan/phpstan-deprecation-rules": "^1.2",
                 "phpunit/phpunit": "^10.4.0",
                 "psr/log": "^1 || ^2 || ^3",
                 "squizlabs/php_codesniffer": "3.7.2",
@@ -763,9 +766,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/orm/issues",
-                "source": "https://github.com/doctrine/orm/tree/3.2.2"
+                "source": "https://github.com/doctrine/orm/tree/3.3.0"
             },
-            "time": "2024-08-23T10:03:52+00:00"
+            "time": "2024-10-12T20:07:18+00:00"
         },
         {
             "name": "doctrine/persistence",
@@ -2708,16 +2711,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.36",
+            "version": "10.5.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "aa0a8ce701ea7ee314b0dfaa8970dc94f3f8c870"
+                "reference": "c7cffa0efa2b70c22366523e6d804c9419eb2400"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/aa0a8ce701ea7ee314b0dfaa8970dc94f3f8c870",
-                "reference": "aa0a8ce701ea7ee314b0dfaa8970dc94f3f8c870",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c7cffa0efa2b70c22366523e6d804c9419eb2400",
+                "reference": "c7cffa0efa2b70c22366523e6d804c9419eb2400",
                 "shasum": ""
             },
             "require": {
@@ -2738,7 +2741,7 @@
                 "phpunit/php-timer": "^6.0.0",
                 "sebastian/cli-parser": "^2.0.1",
                 "sebastian/code-unit": "^2.0.0",
-                "sebastian/comparator": "^5.0.2",
+                "sebastian/comparator": "^5.0.3",
                 "sebastian/diff": "^5.1.1",
                 "sebastian/environment": "^6.1.0",
                 "sebastian/exporter": "^5.1.2",
@@ -2789,7 +2792,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.36"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.37"
             },
             "funding": [
                 {
@@ -2805,7 +2808,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-08T15:36:51+00:00"
+            "time": "2024-10-19T13:03:41+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2977,16 +2980,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.2",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2d3e04c3b4c1e84a5e7382221ad8883c8fbc4f53"
+                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2d3e04c3b4c1e84a5e7382221ad8883c8fbc4f53",
-                "reference": "2d3e04c3b4c1e84a5e7382221ad8883c8fbc4f53",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
+                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
                 "shasum": ""
             },
             "require": {
@@ -2997,7 +3000,7 @@
                 "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.4"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
@@ -3042,7 +3045,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.2"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.3"
             },
             "funding": [
                 {
@@ -3050,7 +3053,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-12T06:03:08+00:00"
+            "time": "2024-10-18T14:56:07+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -3856,10 +3859,10 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
-    "platform-dev": {},
+    "platform": [],
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/src/Database.php
+++ b/src/Database.php
@@ -64,6 +64,8 @@ class Database
      * @param Alert $alert The alert to persist.
      *
      * @return string
+     * 
+     * @see https://www.doctrine-project.org/projects/doctrine-orm/en/3.3/reference/working-with-objects.html#persisting-entities
      */
     protected function persistAlert(
         Alert $alert

--- a/src/Database.php
+++ b/src/Database.php
@@ -2,13 +2,14 @@
 
 namespace Bcgov\NaadConnector;
 
-use Doctrine\DBAL\Connection;
+use Bcgov\NaadConnector\Entity\Alert;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\ORMSetup;
 
 /**
- * Database class mainly used to handle connecting to the database.
+ * Database class for interacting with the database.
  * 
  * @category Database
  * @package  NaadConnector
@@ -19,12 +20,22 @@ use Doctrine\ORM\ORMSetup;
 class Database
 {
 
+    protected EntityManager $entityManager;
+
+    /**
+     * Constructor for Database class.
+     */
+    public function __construct()
+    {
+        $this->entityManager = $this->getEntityManager();
+    }
+
     /**
      * Gets an instance of the Doctrine EntityManager.
      *
      * @return EntityManager
      */
-    static function getEntityManager(): EntityManager
+    protected function getEntityManager(): EntityManager
     {
         // Create a simple "default" Doctrine ORM configuration.
         $config = ORMSetup::createAttributeMetadataConfiguration(
@@ -45,5 +56,51 @@ class Database
             ]
         );
         return new EntityManager($connection, $config);
+    }
+
+    /**
+     * Persists an alert to the database.
+     *
+     * @param Alert $alert The alert to persist.
+     *
+     * @return string
+     */
+    protected function persistAlert(
+        Alert $alert
+    ): string {
+        try {
+            $this->entityManager->persist($alert);
+        } catch(UniqueConstraintViolationException $e) {
+            $this->entityManager = $this->getEntityManager();
+        }
+        return $alert->getId();
+    }
+
+    /**
+     * Inserts an alert into the database.
+     *
+     * @param Alert $alert The alert to insert.
+     *
+     * @return void
+     */
+    public function insertAlert(Alert $alert): void
+    {
+        $this->persistAlert($alert);
+        $this->entityManager->flush();
+    }
+
+    /**
+     * Gets alerts from the database by an array of ids.
+     *
+     * @param array $ids The array of alert ids.
+     *
+     * @return array
+     */
+    public function getAlertsById(array $ids): array
+    {
+        $alertRepository = $this->entityManager->getRepository(Alert::class);
+        $alerts = $alertRepository->findBy(['id' => $ids]);
+        $this->entityManager->flush();
+        return $alerts;
     }
 }

--- a/src/Entity/Alert.php
+++ b/src/Entity/Alert.php
@@ -184,9 +184,7 @@ class Alert
     public static function fromXml(SimpleXMLElement $xml): Alert
     {
         $alert = new Alert();
-        $id = $xml->xpath(
-            '/x:alert/x:identifier'
-        )[0];
+        $id = $xml->identifier;
 
         $alert->setId($id);
         $alert->setBody($xml->asXML());

--- a/src/NaadSocketClient.php
+++ b/src/NaadSocketClient.php
@@ -172,6 +172,8 @@ class NaadSocketClient
 
             // Sets XML error reporting back to its original value.
             libxml_use_internal_errors($previousUseInternalErrorsValue);
+            
+            $this->logger->info(memory_get_usage());
         }
 
         $this->logger->info('Closing socket');
@@ -328,8 +330,8 @@ class NaadSocketClient
         $references = [];
 
         // Separate the references value into sender, id, and sent parts.
-        foreach ($rawReferences as $reference) {
-            $referenceParts = explode(',', $reference);
+        foreach ($rawReferences as $rawReference) {
+            $referenceParts = explode(',', $rawReference);
             $references[] = [
                 'sender' => $referenceParts[0],
                 'id' => $referenceParts[1],


### PR DESCRIPTION
  - NaadSocketClient uses heartbeat message's `references` property to retrieve last 10 alert ids
  - Checks if any of those ids are missing from the database
  - Fetches any missing alerts from NAAD's alert repository
  - Inserts them into the database Updated Database class to perform database queries so database interactions are contained in one class