### PR TITLE
DESCW-2739 refactor passing environment vars to php

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,23 @@
 # Don't change the FROM, updated by the OpenShift BuildConfig.
 FROM php:8.3
-
-# Install Linux package dependencies and PHP extensions
+RUN set -ex; apt update && apt install -y libzip-dev;
 RUN set -ex; \
-  apt update && \
-  apt install -y --no-install-recommends libzip-dev && \
-  docker-php-ext-configure zip && \
-  docker-php-ext-install sockets zip pdo pdo_mysql && \
-  docker-php-ext-enable sockets && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
+  docker-php-ext-configure zip; \
+  docker-php-ext-install sockets zip pdo pdo_mysql; \
+  docker-php-ext-enable sockets;
 
-# Set environment variables
-ENV NAAD_NAME=NAAD-1 \
-    NAAD_URL=streaming1.naad-adna.pelmorex.com \
-    DESTINATION_URL=https://localhost/wp-json/naad/v1/alert \
-    DESTINATION_USER=naadbot \
-    LOG_FILE_PATH="/var/www/html/naad-socket.log"
+ENV LOG_FILE_PATH="/var/www/html/naad-socket.log"
 
-# Add entrypoint script
-COPY ./entrypoint.sh /home/entrypoint.sh
+COPY ./ /var/www/html/
+COPY ./entrypoint.sh /home/
+RUN touch $LOG_FILE_PATH && chown 1001 $LOG_FILE_PATH
 RUN chmod +x /home/entrypoint.sh
 
-# Copy application source code (and composer config)
-COPY ./ /var/www/html/
-
-# Set up secrets for runtime
-RUN --mount=type=secret,id=destination_password \
-  destination_password=$(cat /run/secrets/destination_password) && \
-  echo "destination_password=$destination_password" > /var/www/html/.env
-
-# Create log file and set ownership for non-root group and user
-RUN touch $LOG_FILE_PATH && chown 1001:1001 $LOG_FILE_PATH
-
-# Set the working directory
 WORKDIR /var/www/html/
 
-# Copy the composer executable from the composer:latest image into the new Docker image being built
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
-
-# Switch to non-root user
 USER 1001
+RUN /usr/local/bin/composer install
+RUN /usr/local/bin/composer dump-autoload
 
-# Install PHP dependencies using Composer
-RUN /usr/local/bin/composer install && \
-/usr/local/bin/composer dump-autoload
-
-# Set the entrypoint
 ENTRYPOINT ["/home/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,50 @@
 # Don't change the FROM, updated by the OpenShift BuildConfig.
 FROM php:8.3
-RUN set -ex; apt update && apt install -y libzip-dev;
+
+# Install Linux package dependencies and PHP extensions
 RUN set -ex; \
-  docker-php-ext-configure zip; \
-  docker-php-ext-install sockets zip pdo pdo_mysql; \
-  docker-php-ext-enable sockets;
+  apt update && \
+  apt install -y --no-install-recommends libzip-dev && \
+  docker-php-ext-configure zip && \
+  docker-php-ext-install sockets zip pdo pdo_mysql && \
+  docker-php-ext-enable sockets && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
 
-ENV LOG_FILE_PATH="/var/www/html/naad-socket.log"
+# Set environment variables
+ENV NAAD_NAME=NAAD-1 \
+    NAAD_URL=streaming1.naad-adna.pelmorex.com \
+    DESTINATION_URL=https://localhost/wp-json/naad/v1/alert \
+    DESTINATION_USER=naadbot \
+    LOG_FILE_PATH="/var/www/html/naad-socket.log"
 
-COPY ./ /var/www/html/
-COPY ./entrypoint.sh /home/
-RUN touch $LOG_FILE_PATH && chown 1001 $LOG_FILE_PATH
+# Add entrypoint script
+COPY ./entrypoint.sh /home/entrypoint.sh
 RUN chmod +x /home/entrypoint.sh
 
+# Copy application source code (and composer config)
+COPY ./ /var/www/html/
+
+# Set up secrets for runtime
+RUN --mount=type=secret,id=destination_password \
+  destination_password=$(cat /run/secrets/destination_password) && \
+  echo "destination_password=$destination_password" > /var/www/html/.env
+
+# Create log file and set ownership for non-root group and user
+RUN touch $LOG_FILE_PATH && chown 1001:1001 $LOG_FILE_PATH
+
+# Set the working directory
 WORKDIR /var/www/html/
 
+# Copy the composer executable from the composer:latest image into the new Docker image being built
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
-USER 1001
-RUN /usr/local/bin/composer install
-RUN /usr/local/bin/composer dump-autoload
 
+# Switch to non-root user
+USER 1001
+
+# Install PHP dependencies using Composer
+RUN /usr/local/bin/composer install && \
+/usr/local/bin/composer dump-autoload
+
+# Set the entrypoint
 ENTRYPOINT ["/home/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # NAAD Connector
+
 A PHP client for connecting the National Alert Aggregation & Dissemination (NAAD) System via TCP socket to a REST API.
 
 ## Usage
@@ -6,11 +7,18 @@ A PHP client for connecting the National Alert Aggregation & Dissemination (NAAD
 ### Local
 
 #### Docker deployment
-To build and run via Docker:
-```sh
-docker build -t bcgovgdx/naad-app .
-docker run --rm  bcgovgdx/naad-app
+
+```zsh
+# build only
+composer build
+
+# build and run
+composer start
 ```
+
+- note: _It is no longer possible to run this app from docker because the database requires either docker-compose or K8s deployments in order to manage database migrations and logging._
+
+- This leverages a secret that extracts `DESTINATION_PASSWORD` from your .env file.
 
 #### Docker-Compose deployment
 
@@ -20,17 +28,18 @@ docker run --rm  bcgovgdx/naad-app
 docker compose up
 ```
 
-
 #### Docker Desktop Kubernetes deployment
+
 To build and run in Kubernetes via Docker Desktop:
 Note: Kubernetes must be enabled in Docker Desktop.
+
 ```sh
 kubectl config use-context docker-desktop
 docker build -t bcgovgdx/naad-app .
 kubectl apply -k deployments/kustomize/overlays/local
 ```
 
-PHPMyAdmin will then be accessible at http://0.0.0.0:31008. You may need to use Firefox or Safari to access this as Chrome may block this address due to it not using https.
+PHPMyAdmin will then be accessible at <http://0.0.0.0:31008>. You may need to use Firefox or Safari to access this as Chrome may block this address due to it not using https.
 
 ### OpenShift Build
 
@@ -50,6 +59,6 @@ oc apply -k deployments/kustomize/base --namespace=12345-tools
 
 ### View the database tables (Local only)
 
-- visit http://0.0.0.0:8082 to see the phpMyAdmin page for the naad_connector database. It includes the latest migrations and all alerts that have been recorded.
+- visit <http://0.0.0.0:8082> to see the phpMyAdmin page for the naad_connector database. It includes the latest migrations and all alerts that have been recorded.
 
 _note:  this is mapped to port 8082 to avoid conflict with our wordpress containers_

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ composer start
 
 - note: _It is no longer possible to run this app from docker because the database requires either docker-compose or K8s deployments in order to manage database migrations and logging._
 
-- This leverages a secret that extracts `DESTINATION_PASSWORD` from your .env file.
-
 #### Docker-Compose deployment
 
 - Prerequisites: rename the `./sample-env` to `.env` and fill in the values for local use only.

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
     },
     "scripts": {
         "build": [
-            "docker build --secret id=destination_password,src=.env -t bcgovgdx/naad-app ."
+            "docker build -t bcgovgdx/naad-app ."
         ],
         "start": [
-            "composer run build",
+            "composer build",
             "docker compose up"
         ],
         "stop": [

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "start": [
 
             "composer build",
-            "Composer\\Config::disableProcessTimeout", // allow docker compose to run for longer than 300 seconds.
+            "Composer\\Config::disableProcessTimeout",
             "docker compose up"
         ],
         "stop": [

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,14 @@
     },
     "scripts": {
         "build": [
-            "docker build -t naad-app ."
+            "docker build --secret id=destination_password,src=.env -t bcgovgdx/naad-app ."
         ],
         "start": [
             "composer run build",
-            "docker run --rm --name=naad-app naad-app"
+            "docker compose up"
+        ],
+        "stop": [
+            "docker compose down"
         ],
         "phpcs": [
             "vendor/bin/phpcs ./src"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,9 @@
             "docker build -t bcgovgdx/naad-app ."
         ],
         "start": [
+
             "composer build",
+            "Composer\\Config::disableProcessTimeout", // allow docker compose to run for longer than 300 seconds.
             "docker compose up"
         ],
         "stop": [


### PR DESCRIPTION
rebuilt this branch to account for changes to the base over the weekend.

this is my initial commit, but I expect to start cutting environment variables out of the Dockerfile next.

This small pr will refactor Dockerfile to avoid using a password.

It leverages a secret mount, and extracts that password from your local .env file

This pr also includes updated Docker build/run instructions in the README

Lastly, The scripts which build the image and run it (composer.json) have been altered to work properly. They provide a simple way to build an image and run it:

```bash
#build only
composer build

#build and start the app (docker compose handles the 'swarm' of running containers)
composer start
```

PS. this is just the first requirement of the ticket, and that is why i'm doing a PR onto a feature branch, with more small PRs to follow.