### PR TITLE
DESCW-2318 DestinationClientTest improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,9 @@
     "test-coverage": [
       "vendor/bin/phpunit --coverage-text"
     ],
+    "test-report": [
+      "vendor/bin/phpunit --coverage-html=coverage/"
+    ],
     "migrate": [
       "vendor/bin/doctrine-migrations -vvv -n migrate"
     ]

--- a/src/start.php
+++ b/src/start.php
@@ -14,18 +14,19 @@ $naadVars = new NaadVars();
 // Create a new Database instance.
 $database = new Database();
 
+// Create a custom logger for the NaadSocketConnection.
+$socketLogger = new CustomLogger(
+    'NaadSocketConnection',
+    'info',
+);
+
 // Create a new DestinationClient instance with the provided configuration.
 $destinationClient = new DestinationClient(
     $naadVars->destinationURL,
     $naadVars->destinationUser,
     $naadVars->destinationPassword,
+    $socketLogger,
     $database
-);
-
-// Create a custom logger for the NaadSocketConnection
-$socketLogger = new CustomLogger(
-    'NaadSocketConnection',
-    'info',
 );
 
 $socketClient = new NaadSocketClient(


### PR DESCRIPTION
It was necessary to refactor DestinationClient slightly in order to maximize code coverage:
DestinationClient is now passed the logger and (optionally) a client.
This allows the elimination of reflection classes and 100% code coverage which was otherwise blocked by outer try/catch scenarios.