### PR TITLE
DESCW-2847 fetchAlert should not take an array argument.

### DIFF
--- a/src/NaadRepositoryClient.php
+++ b/src/NaadRepositoryClient.php
@@ -43,22 +43,23 @@ class NaadRepositoryClient
     /**
      * Fetches an alert from the NAAD alert repository.
      *
-     * @param array $reference - The reference data (sender, id, sent).
+     * @param string $id   The Id of the alert.
+     * @param string $sent The sender of the alert.
      *
      * @return string The alert response body.
      *
      * @throws Exception if an error occurs during the GET request.
      */
-    public function fetchAlert(array $reference): string
+    public function fetchAlert(string $id, string $sent): string
     {
-        $url = $this->constructURL($reference);
-
         try {
-            $response = $this->client->get($url);
-            return (string) $response->getBody();
+            $response = $this->client->get($this->constructURL($id, $sent));
+            return $response->getBody()->getContents();
         } catch (RequestException $e) {
             throw new \RuntimeException(
-                "Failed to fetch alert: " . $e->getMessage()
+                "Failed to fetch alert: " . $e->getMessage(),
+                $e->getCode(),
+                $e
             );
         }
     }
@@ -66,18 +67,19 @@ class NaadRepositoryClient
     /**
      * Constructs the URL using the provide reference
      *
-     * @param array $reference Heartbeat references array parts (sender, id, sent).
+     * @param string $id   The Id of the alert.
+     * @param string $sent The sender of the alert.
      *
-     * @return string The constructed URL.
+     * @return string The constructed URL: datestamp, sent, id.
      */
-    protected function constructURL(array $reference): string
+    protected function constructURL(string $id, string $sent): string
     {
         return sprintf(
             self::URL_TEMPLATE,
             $this->baseUrl,
-            strtok($reference['sent'], 'T'), // date
-            strtr($reference['sent'], self::SANITIZE_RULES), // sent
-            strtr($reference['id'], self::SANITIZE_RULES), // id
+            strtok($sent, 'T'),
+            strtr($sent, self::SANITIZE_RULES),
+            strtr($id, self::SANITIZE_RULES),
         );
     }
 

--- a/src/NaadSocketClient.php
+++ b/src/NaadSocketClient.php
@@ -112,14 +112,9 @@ class NaadSocketClient
                     . 'Fetching from NAAD repository ({repoUrl}).',
                     [ 'count' => count($missedAlerts), 'repoUrl' => $repoUrl ]
                 );
-                foreach ( $missedAlerts as $alert ) {
-                    $this->currentOutput = '';
-                    $rawXml = $this->repositoryClient->fetchAlert($alert);
-                    $xml = $this->validateResponse($rawXml);
-                    if ($xml) {
-                        $this->processAlert($xml);
-                    }
-                }
+
+                // Fetch, validate, then process missed alerts.
+                $this->handleMissedAlerts($missedAlerts);
             }
         } else {
             $this->processAlert($xml);
@@ -138,6 +133,34 @@ class NaadSocketClient
 
         $this->currentOutput = '';
         return true;
+    }
+
+    /**
+     * Process missed alerts by fetching and validating their responses.
+     *
+     * @param array $missedAlerts Array of missed alerts with 'id' and 'sent' keys.
+     *
+     * @return array Array of processed alerts.
+     */
+    private function handleMissedAlerts($missedAlerts)
+    {
+        return array_map(
+            // Process the filtered, fetched alerts.
+            fn($xml) => $this->processAlert($xml),
+            // only SimpleXMLElement items remain.
+            array_filter(
+                array_map(
+                    function ($alert) {
+                        return $this->validateResponse(
+                            $this->repositoryClient->fetchAlert(
+                                $alert['id'], $alert['sent']
+                            )
+                        );
+                    },
+                    $missedAlerts
+                )
+            )
+        );
     }
 
     /**

--- a/tests/NaadRepositoryClientTest.php
+++ b/tests/NaadRepositoryClientTest.php
@@ -62,7 +62,7 @@ final class NaadRepositoryClientTest extends TestCase
      * Tests  fetchAlert method with valid response and error.
      *
      * @param array  $mockResponse     The mocked response from the guzzle client
-     * @param array  $reference        The test data used to construct an URL.
+     * @param array  $alert            The test alert data used to construct an URL.
      * @param string $expectedBody     The request response body that
      *                                 should be returned in the fetched Alert.
      * @param bool   $expectsException Whether an exception is expected.
@@ -72,7 +72,7 @@ final class NaadRepositoryClientTest extends TestCase
     #[DataProvider('fetchAlertProvider')]
     public function testFetchAlert(
         $mockResponse,
-        array $reference,
+        array $alert,
         string $expectedBody,
         bool $expectsException
     ): void {
@@ -89,13 +89,15 @@ final class NaadRepositoryClientTest extends TestCase
         }
 
         $client = new NaadRepositoryClient($mockClient, 'naad.url');
+        $id = $alert['id'];
+        $sent = $alert['sent'];
 
         if ($expectsException) {
             $this->expectException(\RuntimeException::class);
             $this->expectExceptionMessage($expectedBody);
-            $client->fetchAlert($reference);
+            $client->fetchAlert($id, $sent);
         } else {
-            $response = $client->fetchAlert($reference);
+            $response = $client->fetchAlert($id, $sent);
             $this->assertEquals($expectedBody, $response);
         }
 

--- a/tests/NaadSocketClientTest.php
+++ b/tests/NaadSocketClientTest.php
@@ -197,8 +197,9 @@ final class NaadSocketClientTest extends TestCase
      */
     public function testHandleResponseMissedAlerts()
     {
-        $database = $this->createStub(Database::class);
+        $database = $this->createMock(Database::class);
         $database->method('getAlertsById')->willReturn([]);
+        $database->expects($this->exactly(10))->method('insertAlert');
 
         $destinationClient = $this->createStub(DestinationClient::class);
         $logger = $this->createStub(CustomLogger::class);
@@ -249,10 +250,11 @@ final class NaadSocketClientTest extends TestCase
             self::XML_TEST_FILE_LOCATION . 'complete-alert.xml'
         );
 
-        $database = $this->createStub(Database::class);
+        $database = $this->createMock(Database::class);
         $database
             ->method('getAlertsById')
             ->willReturn([Alert::fromXml(new SimpleXMLElement($alertXml))]);
+        $database->expects($this->exactly(9))->method('insertAlert');
 
         $destinationClient = $this->createStub(DestinationClient::class);
         $logger = $this->createStub(CustomLogger::class);
@@ -261,7 +263,8 @@ final class NaadSocketClientTest extends TestCase
         // Should only fetch 9 times because one was already in the database.
         $repositoryClient
             ->expects($this->exactly(9))
-            ->method('fetchAlert');
+            ->method('fetchAlert')
+            ->willReturn($alertXml);
 
         $client = new NaadSocketClient(
             'test-naad',


### PR DESCRIPTION
- adapted the NaadRepositoryClient test to use fetcHAlert with 2 string args

- refactored the cod that handles missed alerts in the Naad Socket client:
	- passes 'id' and 'sent' strings to the repo client's fetchAlert
	- broke out a function to perform the fetch, validate, filter, and process operations
- refactored the fetchAlert signature and try/catch block to acocunt for the new string params
- updated the catch block to return more granular exception info.