### PR TITLE
DESCW-2771 Adds tests for Entity/Alert class

### DIFF
--- a/src/Entity/Alert.php
+++ b/src/Entity/Alert.php
@@ -148,17 +148,23 @@ class Alert
      *
      * @param int $failures The number of times the alert has
      *                      failed to send to its destination.
+     *                      and set to 0 if negative.
      *
      * @return void
      */
     public function setFailures( int $failures ): void
     {
-        $this->failures = $failures;
+
+        if ($failures < 0) {
+            $this->failures = 0;
+        } else {
+            $this->failures = $failures;
+        }
     }
 
     /**
      * Increments the number of failures.
-     * 
+     *
      * @return void
      */
     public function incrementFailures(): void
@@ -205,7 +211,7 @@ class Alert
             $errorMessage = 'Invalid XML: The "identifier" field is required.';
             throw new Exception($errorMessage);
         }
-        
+
         $alert = new Alert();
         $alert->setId($identifier);
         $alert->setBody($xml->asXML());

--- a/src/Entity/Alert.php
+++ b/src/Entity/Alert.php
@@ -214,10 +214,9 @@ class Alert
         }
 
         $alert = new self();
-        // Avoiding unnecessary calls to getters and setters
-        $alert->id = $identifier;
-        $alert->body = $xml->asXML();
-        $alert->received = new DateTime();
+        $alert->setId($identifier);
+        $alert->setBody($xml->asXML());
+        $alert->setReceived(new DateTime());
 
         return $alert;
     }

--- a/src/Entity/Alert.php
+++ b/src/Entity/Alert.php
@@ -200,22 +200,24 @@ class Alert
      *
      * @param SimpleXMLElement $xml XML to create alert from.
      *
-     * @return Alert
+     * @return self
      * @throws Exception if the identifier field is missing or empty.
      */
-    public static function fromXml( SimpleXMLElement $xml ): Alert
+    public static function fromXml( SimpleXMLElement $xml ): self
     {
         // Ensure the identifier field is not empty.
-        $identifier = (string) $xml->identifier;
-        if (empty($identifier)) {
-            $errorMessage = 'Invalid XML: The "identifier" field is required.';
-            throw new Exception($errorMessage);
+        $identifier = trim((string) $xml->identifier);
+
+        $err = 'Invalid XML: "identifier" field is required and must not be empty.';
+        if ('' === $identifier) {
+            throw new \InvalidArgumentException($err);
         }
 
-        $alert = new Alert();
-        $alert->setId($identifier);
-        $alert->setBody($xml->asXML());
-        $alert->setReceived(new DateTime());
+        $alert = new self();
+        // Avoiding unnecessary calls to getters and setters
+        $alert->id = $identifier;
+        $alert->body = $xml->asXML();
+        $alert->received = new DateTime();
 
         return $alert;
     }

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -1,0 +1,143 @@
+<?php
+declare(strict_types=1);
+
+namespace Bcgov\NaadConnector\Tests\Entity;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Bcgov\NaadConnector\Entity\Alert;
+
+/**
+ * AlertTest Class for testing Alert class.
+ *
+ * @category Entity
+ * @package  NaadConnector
+ * @author   Michael Haswell <Michael.Haswell@gov.bc.ca>
+ * @license  https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link     https://www.doctrine-project.org/
+ */
+#[CoversClass(Alert::class)]
+final class AlertTest extends TestCase
+{
+    private Alert $alert;
+
+    /**
+     * Set up the test environment before each test method is run.
+     *
+     * This method is called before each test method to initialize
+     * the test environment.
+     * It creates a new instance of the Alert class and assigns it to
+     * the $alert property.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $this->alert = new Alert();
+    }
+
+    #[Test]
+    /**
+     * Test the properties and methods of the Alert class.
+     *
+     * This method tests various setter and getter methods of the Alert class,
+     * including ID, body, received time, send attempted time, failures,
+     * and success status.
+     * It also tests edge cases for the failure count.
+     *
+     * @return void
+     */
+    public function testAlertProperties(): void
+    {
+        $this->alert->setId('12345');
+        $this->alert->setBody('<alert>data</alert>');
+        $this->alert->setReceived(new \DateTime());
+        $this->alert->setSendAttempted(new \DateTime());
+        $this->alert->incrementFailures();
+        $this->alert->setSuccess(true);
+
+        $this->assertEquals('12345', $this->alert->getId());
+        $this->assertEquals('<alert>data</alert>', $this->alert->getBody());
+        $this->assertInstanceOf(\DateTime::class, $this->alert->getReceived());
+        $this->assertInstanceOf(\DateTime::class, $this->alert->getSendAttempted());
+        $this->assertEquals(1, $this->alert->getFailures());
+        $this->assertTrue($this->alert->getSuccess());
+
+        // Test failure count edge cases
+        $this->alert->setFailures(-1);
+        $this->assertEquals(0, $this->alert->getFailures());
+        $this->alert->setFailures(100);
+        $this->assertEquals(100, $this->alert->getFailures());
+    }
+
+    #[Test]
+    /**
+     * Test the fromXml method of the Alert class with valid XML data.
+     *
+     * This test method verifies that the Alert::fromXml() method correctly
+     * creates an Alert object from a valid XML string. It checks if the
+     * created Alert object has the correct identifier, received time,
+     * and body content.
+     *
+     * @return void
+     *
+     * @throws \Exception If there's an error parsing the XML or creating
+     *                    the Alert object.
+     */
+    public function testFromXmlWithValidData(): void
+    {
+        $xmlString = '<?xml version="1.0" encoding="UTF-8"?>
+        <alert>
+            <identifier>12345</identifier>
+            <sender>Example Sender</sender>
+            <sent>2023-05-01T12:00:00-00:00</sent>
+            <status>Actual</status>
+            <msgType>Alert</msgType>
+            <scope>Public</scope>
+        </alert>';
+
+        $xml = new \SimpleXMLElement($xmlString);
+
+        $beforeCreation = new \DateTime();
+        $alert = Alert::fromXml($xml);
+        $afterCreation = new \DateTime();
+
+        $this->assertGreaterThanOrEqual($beforeCreation, $alert->getReceived());
+        $this->assertLessThanOrEqual($afterCreation, $alert->getReceived());
+        $this->assertEquals('12345', $alert->getId());
+        $this->assertStringContainsString(
+            '<identifier>12345</identifier>',
+            $alert->getBody()
+        );
+    }
+
+    #[Test]
+    /**
+     * Test that fromXml method throws an exception when the identifier is empty.
+     *
+     * This test verifies that the Alert::fromXml() method correctly throws an
+     * exception when the XML input contains an empty identifier element. It
+     * ensures that the system properly validates the presence of a required field.
+     *
+     * @return void
+     *
+     * @throws \Exception Expected to be thrown when the identifier is empty.
+     */
+    public function testFromXmlThrowsExceptionWhenIdentifierIsEmpty(): void
+    {
+        $xmlString = '<?xml version="1.0" encoding="UTF-8"?>
+        <alert>
+            <identifier></identifier>
+        </alert>';
+
+        $xml = new \SimpleXMLElement($xmlString);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage(
+            'Invalid XML: The "identifier" field is required.'
+        );
+
+        Alert::fromXml($xml);
+    }
+}

--- a/tests/AlertTest.php
+++ b/tests/AlertTest.php
@@ -22,6 +22,7 @@ use Bcgov\NaadConnector\Entity\Alert;
 final class AlertTest extends TestCase
 {
     private Alert $alert;
+    const XML_TEST_FILE = './tests/Socket/complete-alert.xml';
 
     /**
      * Set up the test environment before each test method is run.
@@ -111,7 +112,7 @@ final class AlertTest extends TestCase
      */
     public function testFromXmlWithValidData(): void
     {
-        $xmlString = $this->getValidXmlString();
+        $xmlString = file_get_contents(self::XML_TEST_FILE);
         $xml = new \SimpleXMLElement($xmlString);
 
         $beforeCreation = new \DateTime();
@@ -120,9 +121,9 @@ final class AlertTest extends TestCase
 
         $this->assertGreaterThanOrEqual($beforeCreation, $alert->getReceived());
         $this->assertLessThanOrEqual($afterCreation, $alert->getReceived());
-        $this->assertEquals('12345', $alert->getId());
+        $this->assertEquals('nrcan:eew:1726439000.0', $alert->getId());
         $this->assertStringContainsString(
-            '<identifier>12345</identifier>',
+            '<identifier>nrcan:eew:1726439000.0</identifier>',
             $alert->getBody()
         );
     }
@@ -148,23 +149,5 @@ final class AlertTest extends TestCase
         $this->expectExceptionMessage($err);
 
         Alert::fromXml($xml);
-    }
-
-    /**
-     * Get a valid XML string for testing
-     *
-     * @return string
-     */
-    private function getValidXmlString(): string
-    {
-        return '<?xml version="1.0" encoding="UTF-8"?>
-        <alert>
-            <identifier>12345</identifier>
-            <sender>Example Sender</sender>
-            <sent>2023-05-01T12:00:00-00:00</sent>
-            <status>Actual</status>
-            <msgType>Alert</msgType>
-            <scope>Public</scope>
-        </alert>';
     }
 }

--- a/tests/NaadSocketClientTest.php
+++ b/tests/NaadSocketClientTest.php
@@ -339,6 +339,7 @@ final class NaadSocketClientTest extends TestCase
         $destinationClient = $this->createStub(DestinationClient::class);
         $logger = $this->createStub(CustomLogger::class);
         $repositoryClient = $this->createStub(NaadRepositoryClient::class);
+        $err = 'Invalid XML: "identifier" field is required and must not be empty.';
 
         $client = new NaadSocketClient(
             'test-naad',
@@ -350,9 +351,7 @@ final class NaadSocketClientTest extends TestCase
         libxml_use_internal_errors(true);
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage(
-            'Invalid XML: The "identifier" field is required.'
-        );
+        $this->expectExceptionMessage($err);
 
         $client->handleResponse(
             file_get_contents(self::XML_TEST_FILE_LOCATION . 'empty-identifier.xml')


### PR DESCRIPTION
[DESCW-2771](https://citz-gdx.atlassian.net/browse/DESCW-2825)

- edits setFailures to handle edge case where $failure is negative.
- tests all trivial setter/getter methods in the same test case
- separates fromXML() Exception and Alert test cases.
![image](https://github.com/user-attachments/assets/1d5d4c0a-3031-4872-8562-ff159d581217)
