### PR TITLE
DESCW-2861 Fix socket pods occassionally crashlooping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ heartbeat.log
 # Ignore documentation files
 /docs/
 .phpdoc
+
+# Ignore development files
+/deployments/kustomize/overlays/development/

--- a/deployments/kustomize/base/app/job.yaml
+++ b/deployments/kustomize/base/app/job.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   template:
     spec:
-      restartPolicy: Never
+      restartPolicy: OnFailure
       containers:
         - name: naad-database-migration
           image: bcgovgdx/naad-app

--- a/src/start.php
+++ b/src/start.php
@@ -11,6 +11,8 @@ use Bcgov\NaadConnector\NaadSocketClient;
 use Bcgov\NaadConnector\NaadSocketConnection;
 use Bcgov\NaadConnector\NaadVars;
 use Bcgov\NaadConnector\NaadRepositoryClient;
+use React\EventLoop\LoopInterface;
+use React\EventLoop\Factory;
 
 use GuzzleHttp\Client;
 
@@ -67,13 +69,16 @@ $socketClient = new NaadSocketClient(
     $repositoryClient,
 );
 
-$reactConnector = new React\Socket\Connector();
+$loop = Factory::create();
+$reactConnector = new React\Socket\Connector($loop);
 $connector = new NaadSocketConnection(
     $naadVars->naadUrl,
     $reactConnector,
     $socketClient,
     $naadSocketConnectionLogger,
+    $loop,
 );
 
-return $connector->connect();
+$connector->connect();
 
+$loop->run();

--- a/tests/NaadSocketConnectionTest.php
+++ b/tests/NaadSocketConnectionTest.php
@@ -14,6 +14,7 @@ use Bcgov\NaadConnector\{
 use React\Promise\Promise;
 use React\Socket\ConnectionInterface;
 use React\Socket\ConnectorInterface;
+use React\EventLoop\LoopInterface;
 
 /**
  * NaadSocketConnectionTest Class for testing NaadSocketConnection.
@@ -44,12 +45,14 @@ final class NaadSocketConnectionTest extends TestCase
         $this->socketClient = $this->createMock(NaadSocketClient::class);
         $this->logger = $this->createMock(Logger::class);
         $this->connection = $this->createMock(ConnectionInterface::class);
+        $this->loop = $this->createMock(LoopInterface::class);
 
         $this->naadSocketConnection = new NaadSocketConnection(
             'ws://localhost',
             $this->connector,
             $this->socketClient,
-            $this->logger
+            $this->logger,
+            $this->loop,
         );
     }
 


### PR DESCRIPTION
Applies a fix to socket pods crash looping:

- On socket close, the pod will attempt to reconnect after a short delay. After 5 failed attempts, it will exit with an error code. A successful reconnect resets the count.
- Transitioned to using a React loop to run the connection rather than a one-and-done function call. This prevents unintended exiting, allows asynchronous calls, and makes the code more extendable in the future.
- Added a keep-alive ping, which seems to reduce socket closures.
- Made the migration job restart on failure so that we don't unnecessarily propagate migration pods.