### PR TITLE
DESCW-2861 Fix socket pods occassionally crashlooping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ heartbeat.log
 # Ignore documentation files
 /docs/
 .phpdoc
+
+# Ignore development files
+/deployments/kustomize/overlays/development/

--- a/deployments/kustomize/base/app/job.yaml
+++ b/deployments/kustomize/base/app/job.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   template:
     spec:
-      restartPolicy: Never
+      restartPolicy: OnFailure
       containers:
         - name: naad-database-migration
           image: bcgovgdx/naad-app

--- a/src/start.php
+++ b/src/start.php
@@ -76,4 +76,3 @@ $connector = new NaadSocketConnection(
 );
 
 return $connector->connect();
-

--- a/tests/NaadSocketConnectionTest.php
+++ b/tests/NaadSocketConnectionTest.php
@@ -74,16 +74,16 @@ final class NaadSocketConnectionTest extends TestCase
         );
 
         $this->logger
-            ->expects($this->exactly(4))
+            ->expects($this->exactly(6))
             ->method('info');
 
         $this->logger->expects($this->once())
             ->method('error')
             ->with($this->stringContains('Exception during socket connection:'));
 
-        // SocketClient->handleResponse should be called 3 times with the data
+        // SocketClient->handleResponse should be called 4 times with the data
         // from the $write variables.
-        $invokedCount = $this->exactly(3);
+        $invokedCount = $this->exactly(4);
         $this->socketClient
             ->expects($invokedCount)
             ->method('handleResponse')


### PR DESCRIPTION
Applies a fix to socket pods crash looping:

- On socket close, the pod will attempt to reconnect. After 5 failed attempts, it will exit with an error code. A successful reconnect resets the count.
- Made the migration job restart on failure so that we don't unnecessarily propagate migration pods.
- Testing the new functionality in our framework is difficult until test sockets are implemented.

