### PR TITLE
DESCW-2921 Secondary fix to prevent crashloops

### DIFF
--- a/deployments/kustomize/base/app/deployment.yaml
+++ b/deployments/kustomize/base/app/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: naad-app
           image: bcgovgdx/naad-app
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           envFrom:
           - configMapRef:
               name: naad1-config
@@ -47,3 +47,18 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 120
             failureThreshold: 3
+      initContainers:
+        - name: wait-for-db
+          image: busybox
+          env:
+            - name: MARIADB_SERVICE_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: database-secrets
+                  key: MARIADB_SERVICE_HOST
+            - name: MARIADB_SERVICE_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: database-secrets
+                  key: MARIADB_SERVICE_PORT
+          command: ['sh', '-c', 'until nc -z $MARIADB_SERVICE_HOST $MARIADB_SERVICE_PORT; do echo waiting for database $MARIADB_SERVICE_HOST; sleep 2; done']

--- a/deployments/kustomize/base/app/deployment2.yaml
+++ b/deployments/kustomize/base/app/deployment2.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: naad-app
           image: bcgovgdx/naad-app
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           envFrom:
           - configMapRef:
               name: naad2-config
@@ -47,3 +47,18 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 120
             failureThreshold: 3
+      initContainers:
+        - name: wait-for-db
+          image: busybox
+          env:
+            - name: MARIADB_SERVICE_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: database-secrets
+                  key: MARIADB_SERVICE_HOST
+            - name: MARIADB_SERVICE_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: database-secrets
+                  key: MARIADB_SERVICE_PORT
+          command: ['sh', '-c', 'until nc -z $MARIADB_SERVICE_HOST $MARIADB_SERVICE_PORT; do echo waiting for database $MARIADB_SERVICE_HOST; sleep 2; done']

--- a/deployments/kustomize/base/app/job.yaml
+++ b/deployments/kustomize/base/app/job.yaml
@@ -26,4 +26,19 @@ spec:
               cpu: 500m
               memory: 1Gi
           command: ['vendor/bin/doctrine-migrations', 'migrate', '--no-interaction', '--allow-no-migration']
+      initContainers:
+        - name: wait-for-db
+          image: busybox
+          env:
+            - name: MARIADB_SERVICE_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: database-secrets
+                  key: MARIADB_SERVICE_HOST
+            - name: MARIADB_SERVICE_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: database-secrets
+                  key: MARIADB_SERVICE_PORT
+          command: ['sh', '-c', 'until nc -z $MARIADB_SERVICE_HOST $MARIADB_SERVICE_PORT; do echo waiting for database $MARIADB_SERVICE_HOST; sleep 2; done']
   backoffLimit: 100


### PR DESCRIPTION
This pull request adds initContainers to the job and both socket deployments.

### Why
The database migration and sockets could crash in the case that they attempt to edit the database before it is ready to accept connections. This happens infrequently for the sockets and regularly for the migration job.

### How
An initContainer is spun up before primary pod deployment, which runs until it determines that the database port is open. After this, the initContainer exits and the primary pod is deployed.

### Considerations
This slows the deployment somewhat, as two pods need to initialize for each component.