### PR TITLE
[DESCW-2884] Restore Sonar default source path configuration

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,5 +1,5 @@
 # Path to sources
-sonar.sources=src
+#sonar.sources=
 #sonar.exclusions=
 #sonar.inclusions=
 


### PR DESCRIPTION
The previous configuration was causing Sonar to not scan deployments, Dockerfile, etc. as it was only pointing to src/