### PR TITLE
DESCW-2947 Remove init containers for migrations and socket deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,13 @@ COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 # Copy application source code (.dockerignore masks out all the unneeded files from the root directory)
 COPY ./ ./
 
-# Copy entrypoint script into /app and set permissions
+# Copy entrypoint and migration scripts into /app
 COPY ./entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh /app/src/alert-cleanup.php
+COPY ./run-migrations.sh /app/run-migrations.sh
 
 # Create non-root user, set permissions, and prepare the environment
-RUN useradd -m -u 1001 appuser && \
+RUN chmod +x /app/entrypoint.sh /app/src/alert-cleanup.php /app/run-migrations.sh && \
+    useradd -m -u 1001 appuser && \
     mkdir -p /app/vendor && \
     touch /app/heartbeat.log && \
     chown -R 1001:0 /app && \

--- a/deployments/kustomize/base/app-statefulset.yaml
+++ b/deployments/kustomize/base/app-statefulset.yaml
@@ -61,10 +61,3 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 120
             failureThreshold: 3
-      initContainers:
-        - name: wait-for-db
-          image: busybox
-          envFrom:
-            - configMapRef:
-                name: database-config
-          command: ['sh', '-c', 'until nc -z $MARIADB_SERVICE_HOST $MARIADB_SERVICE_PORT; do echo waiting for database $MARIADB_SERVICE_HOST; sleep 2; done']

--- a/deployments/kustomize/base/database-migration-job.yaml
+++ b/deployments/kustomize/base/database-migration-job.yaml
@@ -13,7 +13,7 @@ spec:
       containers:
         - name: naad-database-migration
           image: bcgovgdx/naad-app:1.0.0
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           envFrom:
           - configMapRef:
               name: database-config
@@ -28,12 +28,5 @@ spec:
               ephemeral-storage: "1Gi"
               cpu: 500m
               memory: 1Gi
-          command: ['vendor/bin/doctrine-migrations', 'migrate', '--no-interaction', '--allow-no-migration']
-      initContainers:
-        - name: wait-for-db
-          image: busybox
-          envFrom:
-          - configMapRef:
-              name: database-config
-          command: ['sh', '-c', 'until nc -z $MARIADB_SERVICE_HOST $MARIADB_SERVICE_PORT; do echo waiting for database $MARIADB_SERVICE_HOST; sleep 2; done']
+          command: ["/bin/bash", "/app/run-migrations.sh"]
   backoffLimit: 100

--- a/deployments/kustomize/base/kustomization.yaml
+++ b/deployments/kustomize/base/kustomization.yaml
@@ -28,9 +28,6 @@ configMapGenerator:
 - name: database-config
   literals:
     - MARIADB_DATABASE="naad_connector"
-    # Temporary, they will get removed once init containers get removed.
-    - MARIADB_SERVICE_HOST="mariadb"
-    - MARIADB_SERVICE_PORT="3306"
 - name: naad-config
   literals:
     - NAAD_URL=streaming1.naad-adna.pelmorex.com

--- a/run-migrations.sh
+++ b/run-migrations.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+max_retries=5
+retry_delay=10
+attempt=1
+
+# Try to migrate up to max_retries times.
+while [ $attempt -le $max_retries ]
+do
+    echo "Migrating database (Attempt: $attempt/$max_retries)..."
+    /usr/local/bin/php /app/vendor/bin/doctrine-migrations migrate --no-interaction --allow-no-migration
+    # On successful migration, exit with 0 code.
+    if [ $? -eq 0 ]; then
+        exit 0
+    fi
+
+    # Otherwise, try again.
+    echo "Migration failed. Retrying in $retry_delay seconds..."
+    sleep $retry_delay
+    attempt=$((attempt + 1))
+done
+
+echo "Max retries reached. Migration failed."
+exit 1


### PR DESCRIPTION
It does not seem to be possible to alter the database class itself to enact the requested changes, since the doctrine migration script has no retry option and immediately exits on migration failure.

I settled on creating my own script which could be wrapped in retries.

---
This **won't work** for socket deployments, but it is relatively rare for sockets to complete deployment before the database service is ready, so the pods restarting in this case might be useful as visual indicators that something isn't quite right.

---
### Sample migration log
```
 Migrating database (Attempt: 1/5)...

In ExceptionConverter.php line 80:
                                                                               
  An exception occurred in the driver: SQLSTATE[HY000] [2002] Connection time  
  d out                                                                        
                                                                               

In Exception.php line 28:
                                               
  SQLSTATE[HY000] [2002] Connection timed out  
                                               

In PDOConnect.php line 23:
                                               
  SQLSTATE[HY000] [2002] Connection timed out  
                                               

migrations:migrate [--write-sql [WRITE-SQL]] [--dry-run] [--query-time] [--allow-no-migration] [--all-or-nothing [ALL-OR-NOTHING]] [--no-all-or-nothing] [--configuration CONFIGURATION] [--em EM] [--conn CONN] [--db-configuration DB-CONFIGURATION] [--] [<version>]

Migration failed. Retrying in 10 seconds...
Migrating database (Attempt: 2/5)...

In ExceptionConverter.php line 80:
                                                                               
  An exception occurred in the driver: SQLSTATE[HY000] [2002] Connection refu  
  sed                                                                          
                                                                               

In Exception.php line 28:
                                             
  SQLSTATE[HY000] [2002] Connection refused  
                                             

In PDOConnect.php line 23:
                                             
  SQLSTATE[HY000] [2002] Connection refused  
                                             

migrations:migrate [--write-sql [WRITE-SQL]] [--dry-run] [--query-time] [--allow-no-migration] [--all-or-nothing [ALL-OR-NOTHING]] [--no-all-or-nothing] [--configuration CONFIGURATION] [--em EM] [--conn CONN] [--db-configuration DB-CONFIGURATION] [--] [<version>]

Migration failed. Retrying in 10 seconds...
Migrating database (Attempt: 3/5)...
[notice] Migrating up to NaadConnector\Migrations\Version20241004171841
[notice] finished in 30.4ms, used 6M memory, 2 migrations executed, 2 sql queries

 [OK] Successfully migrated to version:                                         
      NaadConnector\Migrations\Version20241004171841                            
```