### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -6,6 +6,8 @@ on:
         paths:
             - 'src/**'
     workflow_dispatch:
+permissions:
+    contents: read
 defaults:
     run:
         working-directory: ./


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/naad-connector/security/code-scanning/30](https://github.com/bcgov/naad-connector/security/code-scanning/30)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function. Based on the workflow's steps, it primarily interacts with OpenShift and does not appear to require write access to the repository. Therefore, we will set `contents: read` as the minimal permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
