### PR TITLE
[DESCW-3232] Remove bcgov/action-builder-ghcr action option causing images to be deleted

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -52,7 +52,6 @@ jobs:
         uses: bcgov/action-builder-ghcr@fd17bc1cbb16a60514e0df3966d42dff9fc232bc #v4.0.0
         with:
           package: naad-connector
-          keep_versions: 1
           build_context: .
           tags: |
             dev


### PR DESCRIPTION
Each time a new image was being built (eg. each PR) previous images were being deleted due to this option.

See: https://github.com/bcgov/naad-connector/pkgs/container/naad-connector%2Fnaad-connector/versions
Only this and PR #105 have images tagged there but it should include the full history of PRs.