### PR TITLE
[DESCW-3249] Fix database-create-user-job commands to use correct syntax

### DIFF
--- a/deployments/kustomize/base/database-create-user-job.yaml
+++ b/deployments/kustomize/base/database-create-user-job.yaml
@@ -9,11 +9,11 @@ metadata:
       app.kubernetes.io/part-of: naad-connector
       app.kubernetes.io/managed-by: argocd
   annotations:
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    app.kubernetes.io/name: database-create-user
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/sync-wave: "1"
 spec:
-  backoffLimit: 3
+  backoffLimit: 100
   template:
     spec:
       restartPolicy: OnFailure

--- a/deployments/kustomize/base/database-create-user-job.yaml
+++ b/deployments/kustomize/base/database-create-user-job.yaml
@@ -24,18 +24,10 @@ spec:
         command: ['sh', '-c']
         args:
           - |
-            # Validate environment variables.
-            : "${MARIADB_SERVICE_HOST:?Missing MARIADB_SERVICE_HOST}"
-            : "${MARIADB_SERVICE_PORT:?Missing MARIADB_SERVICE_PORT}"
-            : "${MARIADB_ROOT_PASSWORD:?Missing MARIADB_ROOT_PASSWORD}"
-            : "${MARIADB_SERVICE_USER:?Missing MARIADB_SERVICE_USER}"
-            : "${MARIADB_SERVICE_PASSWORD:?Missing MARIADB_SERVICE_PASSWORD}"
-            : "${MARIADB_DATABASE:?Missing MARIADB_DATABASE}"
-
             # Create the user and grant it privileges.
-            mariadb -h "$MARIADB_SERVICE_HOST" -P "$MARIADB_SERVICE_PORT" -u root -p"$MARIADB_ROOT_PASSWORD" -e "\
-            CREATE USER IF NOT EXISTS "$MARIADB_SERVICE_USER" IDENTIFIED BY '$MARIADB_SERVICE_PASSWORD';
-            GRANT SELECT, INSERT, UPDATE, DELETE ON "$MARIADB_DATABASE".* TO "$MARIADB_SERVICE_USER"@'%';"
+            mariadb $MARIADB_DATABASE -h "$MARIADB_SERVICE_HOST" -P "$MARIADB_SERVICE_PORT" -u root -p"$MARIADB_ROOT_PASSWORD" -e "
+            CREATE OR REPLACE USER '$MARIADB_SERVICE_USER'@'%' IDENTIFIED BY '$MARIADB_SERVICE_PASSWORD';
+            GRANT CREATE, ALTER, SELECT, INSERT, UPDATE, DELETE ON $MARIADB_DATABASE.* TO '$MARIADB_SERVICE_USER'@'%';"
         envFrom:
           - configMapRef:
               name: database-config

--- a/deployments/kustomize/base/database-migration-job.yaml
+++ b/deployments/kustomize/base/database-migration-job.yaml
@@ -19,6 +19,8 @@ spec:
           - configMapRef:
               name: database-config
           - secretRef:
+              name: database-secrets
+          - secretRef:
               name: root-database-secrets
           resources:
             requests:

--- a/deployments/kustomize/base/database-statefulset.yaml
+++ b/deployments/kustomize/base/database-statefulset.yaml
@@ -1,11 +1,15 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: mariadb
   labels:
     app.kubernetes.io/component: database
 spec:
+  serviceName: mariadb
   replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: database
   template:
     metadata:
       labels:
@@ -14,10 +18,6 @@ spec:
         app.kubernetes.io/instance: naad
         app.kubernetes.io/part-of: naad-connector
     spec:
-      volumes:
-      - name: database-volume
-        persistentVolumeClaim:
-          claimName: mariadb
       automountServiceAccountToken: false
       containers:
       - name: mariadb
@@ -26,8 +26,8 @@ spec:
         ports:
         - containerPort: 3306
         env:
-          - name: MARIADB_ALLOW_EMPTY_ROOT_PASSWORD
-            value: "0"
+        - name: MARIADB_ALLOW_EMPTY_ROOT_PASSWORD
+          value: "0"
         envFrom:
         - configMapRef:
             name: database-config
@@ -45,3 +45,7 @@ spec:
             ephemeral-storage: "1Gi"
             cpu: 500m
             memory: 1Gi
+      volumes:
+      - name: database-volume
+        persistentVolumeClaim:
+          claimName: mariadb

--- a/deployments/kustomize/base/kustomization.yaml
+++ b/deployments/kustomize/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- database-deployment.yaml
+- database-statefulset.yaml
 - database-service.yaml
 - database-volume.yaml
 - database-migration-job.yaml

--- a/deployments/kustomize/base/kustomization.yaml
+++ b/deployments/kustomize/base/kustomization.yaml
@@ -25,8 +25,6 @@ secretGenerator:
   type: Opaque
 - name: root-database-secrets
   literals:
-    - MARIADB_SERVICE_USER="root"
-    - MARIADB_SERVICE_PASSWORD="rootpassword"
     - MARIADB_ROOT_PASSWORD="rootpassword"
   type: Opaque
 


### PR DESCRIPTION
Add database-secrets to database-migration-job
Remove duplicate secret values in kustomization.yaml

Notes:
- This is currently running on the dev and test namespaces.
- Database was changed to a StatefulSet from a Deployment. This allows us to alter the database (eg. change a password), sync it in ArgoCD, and have the database pod restart without manual intervention. As a Deployment it would fail to start up because the old database pod had the exclusive mount of the PVC they're both trying to use.
- Both jobs (create-user and migration) must be deleted in Openshift in order for them to run again (eg. if we change the database user password or a migration needs to be run). This is because Jobs are immutable so even if they change in ArgoCD, they won't be recreated because they have the same name and can't be changed. There is a way to get around this by giving Jobs unique names using hashes but I couldn't get it working.
  - The Jobs will attempt to run after any successful ArgoCD sync, but will only actually run if the current Jobs are deleted.
- Changing the user password now works correctly (as long as the create-user Job is deleted and re-run).
- It is not possible to change the database root user password without manual intervention:
  - Change the root user password manually by executing the SQL statement to change it.
  - Delete the database PVC and allow MariaDB to set its own root password. This works the first time MariaDB starts up because we provide a `MARIADB_ROOT_PASSWORD` env variable, but it does not update the root password on subsequent starts of the database pod because the database already exists in the PVC.